### PR TITLE
Removes additional scopes from GitLab provider

### DIFF
--- a/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationOptions.cs
@@ -26,9 +26,7 @@ namespace AspNet.Security.OAuth.GitLab
             TokenEndpoint = GitLabAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = GitLabAuthenticationDefaults.UserInformationEndpoint;
 
-            Scope.Add("openid");
-            Scope.Add("profile");
-            Scope.Add("email");
+            // Available scopes: https://docs.gitlab.com/ee/integration/oauth_provider.html
             Scope.Add("read_user");
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");


### PR DESCRIPTION
This PR addresses the issue https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/545 as currently by default additional scopes e.g: openid, profile are included.  This isn't optimal as Gitlab will deny the authentication requests that include these additional scopes, if the target Gitlab application settings doesn't have them set as well.
Therefore, it would be better to specify them explicitly when needed.